### PR TITLE
Publish to Content Service

### DIFF
--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import argparse
 import sys
 from os import path
 
@@ -12,6 +13,13 @@ def build(argv):
     """
     Invoke Sphinx with locked arguments to generate JSON content.
     """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--submit",
+                        help="Submit results to the content store.",
+                        action="store_bool")
+
+    args = parser.parse_args(argv[1:])
 
     # I am a terrible person
     BUILTIN_BUILDERS['deconst'] = DeconstJSONBuilder
@@ -27,4 +35,10 @@ def build(argv):
                  freshenv=True, warningiserror=False, tags=[], verbosity=0,
                  parallel=1)
     app.build(True, [])
-    return app.statuscode
+
+    if app.statuscode != 0 or not args.submit:
+        return app.statuscode
+
+    print("submit active")
+
+    return 0

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 import argparse
 import sys
-from os import path
+import os
 
 from builder import DeconstJSONBuilder
 from sphinx.application import Sphinx
@@ -20,6 +22,12 @@ def build(argv):
                         action="store_true")
 
     args = parser.parse_args(argv[1:])
+    content_store_url = os.getenv("CONTENT_STORE")
+
+    if args.submit and not content_store_url:
+        print("Please set CONTENT_STORE if submitting results.",
+              file=sys.stderr)
+        sys.exit(1)
 
     # I am a terrible person
     BUILTIN_BUILDERS['deconst'] = DeconstJSONBuilder
@@ -27,7 +35,7 @@ def build(argv):
     # Lock source and destination to the same paths as the Makefile.
     srcdir, destdir = '.', '_build/deconst'
 
-    doctreedir = path.join(destdir, '.doctrees')
+    doctreedir = os.path.join(destdir, '.doctrees')
 
     app = Sphinx(srcdir=srcdir, confdir=srcdir, outdir=destdir,
                  doctreedir=doctreedir, buildername="deconst",

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -17,7 +17,7 @@ def build(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", "--submit",
                         help="Submit results to the content store.",
-                        action="store_bool")
+                        action="store_true")
 
     args = parser.parse_args(argv[1:])
 

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -16,12 +16,8 @@ def build(argv):
     # I am a terrible person
     BUILTIN_BUILDERS['deconst'] = DeconstJSONBuilder
 
-    try:
-        srcdir, destdir = argv[1], argv[2]
-    except IndexError:
-        print("Insufficient arguments.")
-        print("Please specify source and destination directories.")
-        return 1
+    # Lock source and destination to the same paths as the Makefile.
+    srcdir, destdir = '.', '_build/deconst'
 
     doctreedir = path.join(destdir, '.doctrees')
 

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -47,6 +47,9 @@ def build(argv):
     if app.statuscode != 0 or not args.submit:
         return app.statuscode
 
+    if not content_store_url.endswith("/"):
+        content_store_url += "/"
+
     print("submit active")
 
     return 0

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -63,6 +63,10 @@ def submit_files(content_store_url, dirname, names):
     Submit a directory of generated JSON files to the content store API.
     """
 
+    headers = {
+        "Content-Type": "application/json"
+    }
+
     for name in names:
         fullpath = os.path.join(dirname, name)
         if os.path.isfile(fullpath) and os.path.splitext(name)[1] == ".json":
@@ -74,6 +78,7 @@ def submit_files(content_store_url, dirname, names):
                 payload["body"] = json.load(inf)
 
             response = requests.put(content_store_url + "content",
-                                    data=json.dumps(payload))
+                                    data=json.dumps(payload),
+                                    headers=headers)
             response.raise_for_status()
             print("success")

--- a/deconstrst/deconstrst.py
+++ b/deconstrst/deconstrst.py
@@ -24,12 +24,25 @@ def build(argv):
                         action="store_true")
 
     args = parser.parse_args(argv[1:])
-    content_store_url = os.getenv("CONTENT_STORE")
+    content_store_url = os.getenv("CONTENT_STORE_URL")
+    content_id_base = os.getenv("CONTENT_ID_BASE")
 
-    if args.submit and not content_store_url:
-        print("Please set CONTENT_STORE if submitting results.",
-              file=sys.stderr)
-        sys.exit(1)
+    if args.submit:
+        missing = {}
+
+        if not content_store_url:
+            missing["CONTENT_STORE_URL"] = "Base URL of the content storage " \
+                "service."
+        if not content_id_base:
+            missing["CONTENT_ID_BASE"] = "Base URL used to generate IDs for " \
+                "content within this repository."
+
+        if missing:
+            print("Required environment variables are missing!",
+                  file=sys.stderr)
+            for var, meaning in missing.iteritems():
+                print("  {}\t{}".format(var, meaning), file=sys.stderr)
+            sys.exit(1)
 
     # I am a terrible person
     BUILTIN_BUILDERS['deconst'] = DeconstJSONBuilder

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ docutils==0.12
 Jinja2==2.7.3
 MarkupSafe==0.23
 Pygments==2.0.2
+requests==2.5.3
 Sphinx==1.2.3
 sphinx-bootstrap-theme==0.4.5
 wheel==0.23.0


### PR DESCRIPTION
If the `--submit` command-line argument is supplied, submit to the content store at the address specified by the `CONTENT_STORE` environment variable.